### PR TITLE
Add Windows publish workflow for PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish package
+
+on:
+  push:
+    tags:
+      - 'v*'
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Build distribution
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.8.11
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include LICENSE
+recursive-include examples *


### PR DESCRIPTION
## Summary
- add publish workflow that builds and uploads package to PyPI on tagged releases, running on Windows
- include README, license, and examples in source distribution via MANIFEST.in

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab58b9d4cc8329a337e25bb6dc855e