### PR TITLE
Use Ubuntu for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- use Ubuntu runner in publish workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab65c87c048329bc219c105404f49e