### PR TITLE
ci: validate build metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,9 @@ jobs:
           python-version: '3.x'
       - name: Build distribution
         run: |
-          python -m pip install --upgrade pip build
+          python -m pip install --upgrade pip build twine
           python -m build
+          twine check dist/*
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.11
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,5 +21,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Build package
         run: |
-          python -m pip install --upgrade pip build
+          python -m pip install --upgrade pip build twine
           python -m build
+          twine check dist/*


### PR DESCRIPTION
## Summary
- ensure both publish and CI workflows install and run twine metadata checks after building packages

## Testing
- `python -m pip install --upgrade pip build twine` *(fails: Could not find a version that satisfies the requirement build)*
- `python -m build` *(fails: No module named build)*
- `twine check dist/*` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6c19347c83298b341f3afdb7b342