### PR TITLE
Ensure packaging metadata available for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,9 @@ dependencies = [
     "torch-geometric>=2.3.0",
     "scikit-learn>=1.0"
 ]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/adversarial_nets/__init__.py
+++ b/src/adversarial_nets/__init__.py
@@ -22,7 +22,7 @@ from .utils.utils import (
     objective_function,
 )
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __all__ = [
     "GeneratorBase",
     "GroundTruthGenerator",


### PR DESCRIPTION
## Summary
- configure setuptools to find packages under the src layout
- sync library `__version__` with project metadata

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*

------
https://chatgpt.com/codex/tasks/task_e_68ab749d3f6883299384bc803fa0ed20