### PR TITLE
Add calibration routine with Optuna for adversarial estimator

### DIFF
--- a/examples/linear_in_means_model.ipynb
+++ b/examples/linear_in_means_model.ipynb
@@ -25,7 +25,7 @@
     "$$\n",
     "with $\\lambda_{\\max}(P)$ the spectral radius. (For row-normalized $P$, typically $\\lambda_{\\max}\\le 1$.)\n",
     "\n",
-    "**Why “2-parameter”?** The noise scale (e.g. $\\varepsilon\\sim\\mathcal{N}(0,\\sigma^2 I)$) is **fixed** and not estimated, so the only free structural parameters are the peer effect $\\rho$ and the scalar loading $\\beta$.\n",
+    "**Why \u201c2-parameter\u201d?** The noise scale (e.g. $\\varepsilon\\sim\\mathcal{N}(0,\\sigma^2 I)$) is **fixed** and not estimated, so the only free structural parameters are the peer effect $\\rho$ and the scalar loading $\\beta$.\n",
     "\n",
     "**Adversarial estimation hook.** The generator returns $Y'(\\rho,\\beta)$ for fixed $(X,P)$. Your adversarial loop (same subgraph sampler and discriminator) can keep using cross-entropy on real vs synthetic subgraphs as the outer loss while the optimizer searches over $(\\rho,\\beta)$.\n"
    ]
@@ -313,6 +313,26 @@
    "metadata": {},
    "source": [
     "## Execution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "print(\"\\n4. Calibrating discriminator hyperparameters...\")\n",
+    "search_space = {\n",
+    "    'discriminator_params': {\n",
+    "        'hidden_dim': lambda trial: trial.suggest_int('hidden_dim', 8, 32)\n",
+    "    },\n",
+    "    'training_params': {\n",
+    "        'lr': lambda trial: trial.suggest_float('lr', 1e-4, 1e-2, log=True),\n",
+    "        'batch_size': lambda trial: trial.suggest_categorical('batch_size', [64, 128, 256])\n",
+    "    }\n",
+    "}\n",
+    "optimizer_params = {'n_trials': 30}\n",
+    "estimator.callibrate(search_space, optimizer_params, metric_name='ace', k=10)\n"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     "scipy>=1.7.0",
     "torch>=2.0.0",
     "torch-geometric>=2.3.0",
-    "scikit-learn>=1.0"
+    "scikit-learn>=1.0",
+    "optuna>=3.0.0",
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ tqdm>=4.62.0
 scipy>=1.7.0
 torch>=2.0.0
 torch-geometric>=2.3.0
-torch-geometric>=2.3.0
 scikit-learn>=1.0
 numba>=0.55
+optuna>=3.0.0

--- a/src/adversarial_nets/utils/utils.py
+++ b/src/adversarial_nets/utils/utils.py
@@ -1,7 +1,8 @@
 import torch
 import torch.nn as nn
-from torch_geometric.loader import DataLoader 
+from torch_geometric.loader import DataLoader
 import random
+import numpy as np
 from sklearn.model_selection import train_test_split
 
 
@@ -32,11 +33,10 @@ def create_dataset(real_subgraphs, synthetic_subgraphs):
 
 
 def evaluate_discriminator(model, loader, device, metric="neg_logloss"):
-    """
-    Evaluate the discriminator model according to a specified metric.
+    """Evaluate the discriminator model according to a specified metric.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     model : torch.nn.Module
         The GNN discriminator model
     loader : torch_geometric.data.DataLoader
@@ -45,19 +45,21 @@ def evaluate_discriminator(model, loader, device, metric="neg_logloss"):
         Device to run computations on
     metric : str
         Metric to compute. Supported values are ``"neg_logloss"``,
-        ``"accuracy"`` and ``"neg_brier_score"``.
+        ``"accuracy"``, ``"neg_brier_score"``, ``"ace"`` (average calibration
+        error) and ``"ece"`` (expected calibration error).
 
-    Returns:
-    --------
+    Returns
+    -------
     float
-        Evaluation value according to ``metric``. For ``"accuracy"`` the
-        value is the standard accuracy score. For the other options the value
-        is negated so that lower values correspond to better discriminator
+        Evaluation value according to ``metric``. For ``"accuracy"`` the value
+        is the standard accuracy score. For the other options the value is
+        defined so that lower values correspond to better discriminator
         performance; hence they can be directly minimized by the outer
         optimization routine.
     """
 
     from sklearn.metrics import accuracy_score, brier_score_loss, log_loss
+    from sklearn.calibration import calibration_curve
 
     model.eval()
     y_true = []
@@ -75,19 +77,33 @@ def evaluate_discriminator(model, loader, device, metric="neg_logloss"):
             y_pred.extend(preds.cpu().numpy())
             y_prob.extend(probs.cpu().numpy())
 
+    y_true = np.asarray(y_true)
+    y_prob = np.asarray(y_prob)
+
     if metric == "neg_logloss":
         value = -log_loss(y_true, y_prob, labels=[0, 1])
     elif metric == "accuracy":
         value = accuracy_score(y_true, y_pred)
     elif metric == "neg_brier_score":
         value = -brier_score_loss(y_true, y_prob)
+    elif metric in {"ace", "ece"}:
+        prob_true, prob_pred = calibration_curve(y_true, y_prob, n_bins=10, strategy="uniform")
+        bins = np.linspace(0.0, 1.0, 11)
+        binids = np.digitize(y_prob, bins) - 1
+        bin_total = np.bincount(binids, minlength=10)
+        nonzero = bin_total > 0
+        diff = np.abs(prob_true - prob_pred)
+        if metric == "ace":
+            value = diff.mean()
+        else:
+            weights = bin_total[nonzero] / len(y_prob)
+            value = np.sum(diff * weights)
     else:
         raise ValueError(
-            "metric must be one of 'neg_logloss', 'accuracy', 'neg_brier_score'"
+            "metric must be one of 'neg_logloss', 'accuracy', 'neg_brier_score', 'ace', 'ece'",
         )
 
     return value
-
 
 def objective_function(
     theta,


### PR DESCRIPTION
## Summary
- add Optuna-based `callibrate` method to tune discriminator and training hyperparameters
- extend discriminator evaluation with ACE/ECE calibration metrics
- include calibration step in example notebook and add Optuna dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb2c05c3348329ad88cdb02b2732a2