### PR TITLE
Expose calibration verbosity control and restructure example notebook

### DIFF
--- a/examples/linear_in_means_model.ipynb
+++ b/examples/linear_in_means_model.ipynb
@@ -25,7 +25,7 @@
     "$$\n",
     "with $\\lambda_{\\max}(P)$ the spectral radius. (For row-normalized $P$, typically $\\lambda_{\\max}\\le 1$.)\n",
     "\n",
-    "**Why “2-parameter”?** The noise scale (e.g. $\\varepsilon\\sim\\mathcal{N}(0,\\sigma^2 I)$) is **fixed** and not estimated, so the only free structural parameters are the peer effect $\\rho$ and the scalar loading $\\beta$.\n",
+    "**Why \u201c2-parameter\u201d?** The noise scale (e.g. $\\varepsilon\\sim\\mathcal{N}(0,\\sigma^2 I)$) is **fixed** and not estimated, so the only free structural parameters are the peer effect $\\rho$ and the scalar loading $\\beta$.\n",
     "\n",
     "**Adversarial estimation hook.** The generator returns $Y'(\\rho,\\beta)$ for fixed $(X,P)$. Your adversarial loop (same subgraph sampler and discriminator) can keep using cross-entropy on real vs synthetic subgraphs as the outer loss while the optimizer searches over $(\\rho,\\beta)$.\n"
    ]
@@ -212,6 +212,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Discriminator model\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "7",
@@ -308,10 +315,16 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "10",
+   "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "## Generate dataset\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
    "outputs": [],
    "source": [
     "print(\"Testing Adversarial Estimation for Linear-in-Means Model\")\n",
@@ -319,7 +332,22 @@
     "true_params = [0.5, 0.75]\n",
     "print(\"\\n1. Generating test dataset...\")\n",
     "test_data = create_test_graph_dataset(num_nodes=N_NODES, true_a=true_params[0], true_b=true_params[1], p=P)\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create estimator\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
     "print(\"\\n2. Creating adversarial estimator...\")\n",
     "estimator = AdversarialEstimator(\n",
     "    ground_truth_data=test_data,\n",
@@ -341,20 +369,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
    "metadata": {},
    "source": [
-    "## Execution"
+    "## Calibrate discriminator hyperparameters\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "12",
    "metadata": {},
+   "execution_count": null,
    "outputs": [],
    "source": [
-    "print(\"\\n4. Calibrating discriminator hyperparameters...\")\n",
+    "print(\"\\n3. Calibrating discriminator hyperparameters...\")\n",
     "search_space = {\n",
     "    'discriminator_params': {\n",
     "        'hidden_dim': lambda trial: trial.suggest_int('hidden_dim', 8, 32)\n",
@@ -365,52 +391,55 @@
     "    }\n",
     "}\n",
     "optimizer_params = {'n_trials': 30}\n",
-    "estimator.callibrate(search_space, optimizer_params, metric_name='ace', k=10)\n"
+    "seeds = [0, 1, 2]\n",
+    "for seed in seeds:\n",
+    "    print(f\"  Seed {seed}\")\n",
+    "    np.random.seed(seed)\n",
+    "    random.seed(seed)\n",
+    "    torch.manual_seed(seed)\n",
+    "    estimator.callibrate(search_space, optimizer_params, metric_name='ace', k=10)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Adversarial estimation\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "13",
    "metadata": {},
+   "execution_count": null,
    "outputs": [],
    "source": [
-    "print(\"\\n3. Visualizing objective function surface...\")\n",
-    "\n",
-    "'''\n",
-    "visualize_objective_surface(a\n",
-    "    estimator,\n",
+    "print(\"\n",
+    "4. Running adversarial estimation...\")\n",
+    "result = estimator.estimate(\n",
     "    m=N_SAMPLES,\n",
-    "    resolution=RESOLUTION,\n",
     "    num_epochs=N_EPOCHS,\n",
     "    verbose=True,\n",
-    ")\n",
-    "'''\n",
-    "print(\"\\n4. Running adversarial estimation...\")\n",
-    "result = estimator.estimate(\n",
-    "m=N_SAMPLES, \n",
-    "num_epochs=N_EPOCHS, \n",
-    "verbose=True, \n",
-    "training_params=dict(\n",
+    "    training_params=dict(\n",
     "        lr=5e-3,\n",
-    "        batch_size = 256\n",
-    "        ),\n",
-    "k_hops=1\n",
+    "        batch_size=256,\n",
+    "    ),\n",
+    "    k_hops=1,\n",
     ")\n",
     "\n",
     "estimated_params = result['x'] if isinstance(result, dict) else result.x\n",
     "estimator.estimated_params = estimated_params\n",
     "\n",
-    "print(\"\\n5. Results:\")\n",
+    "print(\"\n",
+    "5. Results:\")\n",
     "print(f\"   - True parameters: alpha={true_params[0]}, beta={true_params[1]}\")\n",
     "print(f\"   - Estimated parameters: alpha={estimated_params[0]:.4f}, beta={estimated_params[1]:.4f}\")\n",
     "print(\n",
-    "f\"   - Estimation error: alpha_error={abs(estimated_params[0] - true_params[0]):.4f}, \"\n",
-    "f\"beta_error={abs(estimated_params[1] - true_params[1]):.4f}\"\n",
+    "    f\"   - Estimation error: alpha_error={abs(estimated_params[0] - true_params[0]):.4f}, \"\n",
+    "    f\"beta_error={abs(estimated_params[1] - true_params[1]):.4f}\"\n",
     ")\n",
     "\n",
     "plt.tight_layout()\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   }
  ],

--- a/src/adversarial_nets/estimator/estimator.py
+++ b/src/adversarial_nets/estimator/estimator.py
@@ -1,6 +1,7 @@
 from skopt import gp_minimize
 import optuna
 import random
+from tqdm import tqdm
 from ..generator.generator import GroundTruthGenerator, SyntheticGenerator
 from ..utils.utils import objective_function
 
@@ -134,7 +135,7 @@ class AdversarialEstimator:
             m=1500,
             num_epochs=5,
             k_hops=1,
-            verbose=True,
+            discriminator_verbose=False,
         ):
         """Calibrate discriminator hyperparameters using Optuna.
 
@@ -155,12 +156,13 @@ class AdversarialEstimator:
         m, num_epochs, k_hops : int, optional
             Arguments controlling subgraph sampling and discriminator
             training. They can be overridden by sampled training parameters.
-        verbose : bool, optional
-            Whether to print progress information.
+        discriminator_verbose : bool, optional
+            Whether to print discriminator training progress.
         """
 
         n_trials = optimizer_params.pop("n_trials", 50)
         study = optuna.create_study(direction="minimize", **optimizer_params)
+        pbar = tqdm(total=n_trials * k, desc="Calibrating")
 
         def objective(trial):
             disc_search = search_space.get("discriminator_params", {})
@@ -184,15 +186,17 @@ class AdversarialEstimator:
                     m=m_trial,
                     num_epochs=num_epochs_trial,
                     k_hops=k_hops_trial,
-                    verbose=verbose,
+                    verbose=discriminator_verbose,
                     metric=metric_name,
                     discriminator_params=disc_params,
                     **train_params,
                 )
                 performances.append(perf)
+                pbar.update(1)
             return float(sum(performances) / len(performances))
 
-        study.optimize(objective, n_trials=n_trials)
+        study.optimize(objective, n_trials=n_trials, show_progress_bar=False)
+        pbar.close()
 
         self.calibrated_params = study.best_params
         self.calibration_study = study


### PR DESCRIPTION
## Summary
- Add progress bar and `discriminator_verbose` parameter to Optuna-based calibration
- Reorganize linear-in-means example with clearer stepwise cells and varied calibration seeds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc610b679c8329aa9ca905a1468527