### PR TITLE
Add support for repeated objective evaluations

### DIFF
--- a/src/adversarial_nets/utils/utils.py
+++ b/src/adversarial_nets/utils/utils.py
@@ -205,7 +205,9 @@ def objective_function(
 
         dataset = create_dataset(real_subgraphs, synthetic_subgraphs)
 
-        train_data, test_data = train_test_split(dataset, test_size=0.3, random_state=42)
+        train_data, test_data = train_test_split(
+            dataset, test_size=0.3, random_state=train_seed
+        )
         train_loader = DataLoader(train_data, batch_size=batch_size, shuffle=True)
         test_loader = DataLoader(test_data, batch_size=batch_size, shuffle=False)
 


### PR DESCRIPTION
## Summary
- add `num_runs` option to `estimate` and `callibrate` to average multiple trainings per evaluation
- ensure each run draws fresh train/test splits using new seed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdd142d60c8329b892a3db96977815