### PR TITLE
Add Nelder-Mead option to adversarial estimator

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ At the optimal discriminator this minimizes the Jensen–Shannon divergence betw
 
   * *Ground-truth generator*: sampling manager over \$G\$ to produce \$g\sim p\_{\mathrm{data}}^{\mathsf{S}}\$.
   * *Synthetic generator*: wraps \$m\_\theta\$, reuses \$X\$, \$A\$ and the chosen initial state \$Y^{(0)}\$ (passed through the estimator), constructs \$P(A)\$ with zero diagonal, and exposes `generate_outcomes(θ)` for counterfactual simulation.
-* **Optimization.** Treat the outer problem as black-box in \$\theta\$. Bayesian optimization is a reasonable default; use **binary cross-entropy** from the objective above (not accuracy) as the scalar loss.
+* **Optimization.** Treat the outer problem as black-box in \$\theta\$. Bayesian optimization is a reasonable default; use **binary cross-entropy** from the objective above (not accuracy) as the scalar loss. The estimator exposes an ``outer_optimizer`` switch: keep ``"gp"`` (default, via ``skopt.gp_minimize``) or set ``"nelder-mead"`` to activate SciPy's derivative-free simplex routine. Additional optimizer arguments can be supplied through ``outer_optimizer_params`` (legacy code using ``gp_params`` continues to work when the GP optimizer is selected). SciPy is declared as a project dependency.
 
 ## `linear_in_means_model.ipynb`
 

--- a/src/adversarial_nets/estimator/estimator.py
+++ b/src/adversarial_nets/estimator/estimator.py
@@ -1,6 +1,9 @@
-from skopt import gp_minimize
-import optuna
 import random
+
+import numpy as np
+import optuna
+from scipy.optimize import minimize
+from skopt import gp_minimize
 from tqdm.auto import tqdm
 from ..generator.generator import GroundTruthGenerator, SyntheticGenerator
 from ..utils.utils import objective_function
@@ -15,6 +18,8 @@ class AdversarialEstimator:
             discriminator_factory,
             gp_params=None,
             metric="neg_logloss",
+            outer_optimizer="gp",
+            outer_optimizer_params=None,
         ):
         """
         Initialize the adversarial estimator.
@@ -35,10 +40,21 @@ class AdversarialEstimator:
         discriminator_factory : callable
             Callable returning a discriminator model given ``input_dim``
         gp_params : dict, optional
-            Additional parameters passed to ``gp_minimize``
+            Additional parameters passed to ``gp_minimize``. Retained for
+            backward compatibility with earlier versions of the API.
         metric : str, optional
             Evaluation metric for the discriminator. Passed to
             :func:`objective_function`.
+        outer_optimizer : {"gp", "nelder-mead"}, optional
+            Outer optimization routine. Defaults to Gaussian process based
+            Bayesian optimization (``"gp"``). Set to ``"nelder-mead"`` to use
+            SciPy's derivative-free simplex solver.
+        outer_optimizer_params : dict, optional
+            Additional keyword arguments forwarded to the selected outer
+            optimizer. When ``outer_optimizer="gp"`` these correspond to
+            parameters of :func:`skopt.gp_minimize`. When
+            ``outer_optimizer="nelder-mead"`` they are passed to
+            :func:`scipy.optimize.minimize`.
         """
         self.ground_truth_generator = GroundTruthGenerator(
             ground_truth_data.X,
@@ -56,8 +72,37 @@ class AdversarialEstimator:
         self.initial_params = initial_params
         self.bounds = bounds
         self.discriminator_factory = discriminator_factory
-        self.gp_params = gp_params or {}
         self.metric = metric
+        self.outer_optimizer = (outer_optimizer or "gp").lower()
+
+        valid_optimizers = {"gp", "nelder-mead"}
+        if self.outer_optimizer not in valid_optimizers:
+            raise ValueError(
+                f"Unsupported outer optimizer '{outer_optimizer}'. "
+                f"Expected one of {sorted(valid_optimizers)}."
+            )
+
+        params_candidates = []
+        if gp_params is not None:
+            params_candidates.append(gp_params)
+        if outer_optimizer_params is not None:
+            params_candidates.append(outer_optimizer_params)
+
+        if len(params_candidates) > 1:
+            raise ValueError(
+                "Specify either 'gp_params' or 'outer_optimizer_params', not both."
+            )
+
+        base_params = params_candidates[0] if params_candidates else {}
+        base_dict = dict(base_params) if base_params else {}
+        if self.outer_optimizer == "gp":
+            # Keep gp_params alias for backwards compatibility. Mutations on
+            # either attribute affect the same underlying dictionary.
+            self.gp_params = base_dict
+            self.outer_optimizer_params = self.gp_params
+        else:
+            self.outer_optimizer_params = base_dict
+            self.gp_params = dict(gp_params or {})
         self.calibrated_params = None
         self.calibration_study = None
 
@@ -149,36 +194,127 @@ class AdversarialEstimator:
                 **training_params
             )
         
-        gp_options = {
-            'n_calls': 150,
-            'n_initial_points': 70,
-            'noise': 0.1,
-            'acq_func': 'EI',
-            'random_state': 42,
-            'n_jobs': -1,
-            'verbose': verbose,
-        }
+        if self.outer_optimizer == "gp":
+            gp_options = {
+                "n_calls": 150,
+                "n_initial_points": 70,
+                "noise": 0.1,
+                "acq_func": "EI",
+                "random_state": 42,
+                "n_jobs": -1,
+                "verbose": verbose,
+            }
 
-        gp_options.update(self.gp_params)
+            gp_options.update(dict(self.outer_optimizer_params))
 
-        total_calls = gp_options.get('n_calls', 0)
-        pbar = tqdm(total=total_calls, desc="Estimating") if verbose else None
+            total_calls = gp_options.get("n_calls", 0)
+            pbar = tqdm(total=total_calls, desc="Estimating") if verbose else None
 
-        def _callback(res):
+            def _callback(res):
+                if pbar is not None:
+                    pbar.update(1)
+
+            result = gp_minimize(
+                objective_with_generator,
+                self.bounds,
+                callback=[_callback],
+                **gp_options,
+            )
+
             if pbar is not None:
-                pbar.update(1)
+                pbar.close()
 
-        result = gp_minimize(
-            objective_with_generator,
-            self.bounds,
-            callback=[_callback],
-            **gp_options
+            return result
+
+        if self.outer_optimizer == "nelder-mead":
+            nm_params = dict(self.outer_optimizer_params)
+
+            options_user = nm_params.pop("options", {}) or {}
+            x0 = nm_params.pop("x0", self.initial_params)
+            if x0 is None:
+                raise ValueError(
+                    "Nelder-Mead optimization requires an initial parameter vector."
+                )
+
+            lower_bounds = upper_bounds = None
+            if self.bounds:
+                lower_bounds = np.array(
+                    [(-np.inf if low is None else low) for (low, _) in self.bounds],
+                    dtype=float,
+                )
+                upper_bounds = np.array(
+                    [(np.inf if high is None else high) for (_, high) in self.bounds],
+                    dtype=float,
+                )
+
+            x0 = np.asarray(x0, dtype=float)
+            if lower_bounds is not None:
+                x0 = np.clip(x0, lower_bounds, upper_bounds)
+
+            default_options = {
+                "maxiter": 200,
+                "xatol": 1e-4,
+                "fatol": 1e-4,
+                "adaptive": True,
+            }
+            default_options.update(options_user)
+            default_options.setdefault("disp", verbose)
+            default_options["disp"] = bool(default_options["disp"])
+
+            estimated_total = default_options.get("maxiter") or default_options.get("maxfev")
+            pbar = tqdm(total=estimated_total, desc="Estimating") if verbose else None
+
+            user_callback = nm_params.pop("callback", None)
+            user_tol = nm_params.pop("tol", None)
+            user_args = nm_params.pop("args", ())
+            if nm_params.pop("bounds", None) is not None:
+                # Bounds are handled manually through clipping. Ignore any provided
+                # bounds to avoid SciPy raising an error for unsupported arguments.
+                pass
+
+            minimize_kwargs = nm_params
+            if user_args:
+                minimize_kwargs["args"] = user_args
+            if user_tol is not None:
+                minimize_kwargs["tol"] = user_tol
+
+            def _clip(theta):
+                theta = np.asarray(theta, dtype=float)
+                if lower_bounds is not None:
+                    theta = np.clip(theta, lower_bounds, upper_bounds)
+                return theta
+
+            def nm_objective(theta):
+                clipped_theta = _clip(theta)
+                return objective_with_generator(clipped_theta.tolist())
+
+            def wrapped_callback(xk, *cb_args):
+                if pbar is not None:
+                    pbar.update(1)
+                if user_callback is not None:
+                    user_callback(_clip(xk), *cb_args)
+
+            result = minimize(
+                nm_objective,
+                x0,
+                method="Nelder-Mead",
+                callback=wrapped_callback,
+                options=default_options,
+                **minimize_kwargs,
+            )
+
+            if pbar is not None:
+                pbar.close()
+
+            if lower_bounds is not None:
+                result.x = _clip(result.x)
+
+            return result
+
+        raise ValueError(
+            f"Unsupported outer optimizer '{self.outer_optimizer}'. "
+            "Expected 'gp' or 'nelder-mead'."
         )
-
-        if pbar is not None:
-            pbar.close()
-
-        return result
 
     def callibrate(
             self,


### PR DESCRIPTION
## Summary
- add a configurable outer optimizer option to the adversarial estimator with support for SciPy's Nelder-Mead simplex routine
- keep the Gaussian-process defaults while sharing configuration plumbing for both optimizers and handling bounds clipping for Nelder-Mead
- document how to select the optimizer and pass parameters in the README

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d023db3cb88329ba80107e988a6165